### PR TITLE
Update the packaging of liblouis native dll and supporting files

### DIFF
--- a/src/SharpLouis/SharpLouis.csproj
+++ b/src/SharpLouis/SharpLouis.csproj
@@ -28,12 +28,16 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Include="LibLouis/**">
+        <!-- Content is included in packages by default. Much more detail on packing can be found at
+             https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets -->
+        <Content Include="LibLouis\**" Exclude="LibLouis\liblouis.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-            <Pack>true</Pack>
             <Visible>false</Visible>
-            <PackagePath>lib/$(TargetFramework)/LibLouis</PackagePath>
+            <!-- But by default the Content won't be included by projects that reference your package. This metadata
+                 changes that default behavior.  -->
+            <PackageCopyToOutput>true</PackageCopyToOutput>
         </Content>
+        <Content Include="./LibLouis/liblouis.dll" PackagePath="runtimes/win-x64/native" />
         <None Include="../../README.md" Pack="true" Visible="false" PackagePath="/docs" />
         <None Include="../../CHANGELOG.md" Pack="true" Visible="false" PackagePath="/docs" />
     </ItemGroup>


### PR DESCRIPTION
The native liblouis.dll file must be packaged in a path of the form `runtimes/<RID>/native>` where `<RID>` is the runtime identifier of the target platform the dll is built for - in this case win-x64. With this done, NuGet will handle the dependency flow for projects that reference the SharpLouis package.

The supporting tables files must also be flowed into the output of referencing projects, so we use the default NuGet behavior of bundling Content MSBuild Items into the `content/` directory of the package, as well as telling NuGet that these pieces of content should be copied to the output directory of the referencing project.

Details on these behaviors can be referenced at [the NuGet docs](https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets).

As a before-and-after of this change's impact, here is a snippet of the `project.assets.json` from my test consuming project for the current version of AccessMind.SharpLouis. This is just a sample because the file is quite large:

```json
{
  ...
  "targets": {
    "net8.0": {
      "AccessMind.SharpLouis/1.0.0": {
        "type": "package",
        "compile": {
          "lib/net8.0/SharpLouis.dll": {}
        },
        "runtime": {
          "lib/net8.0/SharpLouis.dll": {}
        }
  ...
}
```

In this snippet, NuGet only knows about the single managed SharpLouis assembly. After changing the project file to put the native liblouis.dll in `runtimes/win-x64/native`, the project.assets.json file changes to the following:

```json
{
  ...
  "targets": {
    "net8.0": {
      "AccessMind.SharpLouis/1.0.0": {
        "type": "package",
        "compile": {
          "lib/net8.0/SharpLouis.dll": {}
        },
        "runtime": {
          "lib/net8.0/SharpLouis.dll": {}
        },
        "runtimeTargets": {
          "runtimes/win-x64/native/liblouis.dll": {
            "assetType": "native",
            "rid": "win-x64"
          }
        }
  ...
}
```

Note the inclusion of the `runtimeTargets` property, which tells the rest of the build that there are native assets available when targeting win-x64.

Now we need the tables and supporting files. For this, we need NuGet to package the files as 'content' and also tell the build to copy the content to the output directory of the referencing project. To get NuGet to package the files as 'content', we can take advantage of the default NuGet behavior of making `Content` MSBuild items behave as NuGet content as well. To get NuGet to tell the build to copy the content to the project's output folder, we can set the `<PackageCopyToOutput>true</PackageCopyToOutput>` metadata. Once we do these two things, the project.assets.json changes again to include _a lot_ of new content:

```json
{
  ...
  "targets": {
    "net8.0": {
      "AccessMind.SharpLouis/1.0.0": {
        "type": "package",
        "compile": {
          "lib/net8.0/SharpLouis.dll": {}
        },
        "runtime": {
          "lib/net8.0/SharpLouis.dll": {}
        },
        "contentFiles": {
          "contentFiles/any/net8.0/LibLouis/tables.json": {
            "buildAction": "Content",
            "codeLanguage": "any",
            "copyToOutput": true,
            "outputPath": "LibLouis/tables.json"
          },
          ...
        },
        "runtimeTargets": {
          "runtimes/win-x64/native/liblouis.dll": {
            "assetType": "native",
            "rid": "win-x64"
          }
        }
  ...
}
```

I elided the vast majority of the content here because it's thousands of lines of json, but it's all there - the outer tables.json manifest and the individual tables in the `tables` directory.

Taken together, when I publish my test project via `dotnet publish -r win-x64`, I get the following directory structure in the final `publish` directory for the `win-64` runtime identifier:

```terminal
.
├── LibLouis
│   ├── tables
│   │   ├── afr-za-g1.ctb and many other individual tables
│   └── tables.json
├── liblouis.dll
├── SharpLouis.dll
├── sharplouistest.deps.json
├── sharplouistest.dll
├── sharplouistest.exe
├── sharplouistest.pdb
└── sharplouistest.runtimeconfig.json
```

Is this correct? Is the 'wrapper' LibLouis folder desired or expected, or should the `tables` directory be a sibling of the `liblouis.dll` directly?



