### PR TITLE
Make TableCollection fluent filters non-destructive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] — 2026-07-06
+
+### Fixed 🐛
+
+- `TableCollection.FindByLanguage()` and `FindLiterary()` are now non-destructive: each returns a new
+  collection and leaves the receiver unchanged, matching the documented fluent interface. They
+  previously mutated the collection in place, so reusing a populated instance for a second query gave
+  wrong results — for example `ListLanguages()` after `FindLiterary()` listed only the languages that
+  have a literary table, silently dropping the rest.
+
 ## [2.0.0] — 2026-07-04
 
 This release contains several breaking API changes (see **Changed** below), so it is a major version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ dotnet test SharpLouis.sln
 - `src/SharpLouis/` - Main project directory
   - `SharpLouis.csproj` - Project file with all build configuration
   - `BrailleTranslator.cs` - Main translator class with P/Invoke declarations and translation methods
-  - `TableCollection.cs` - Fluent API for filtering translation tables
+  - `TableCollection.cs` - Fluent API for filtering translation tables (filters are non-destructive: `FindByLanguage`/`FindLiterary` return a new collection and leave the receiver unchanged, so one populated collection can be reused for several independent queries)
   - `TranslationTable.cs` - Translation table metadata structure
   - `TranslationModes.cs` - Translation mode flags enum
   - `TypeForm.cs` - Typeform enum for emphasis styles
@@ -65,6 +65,19 @@ dotnet test SharpLouis.sln
 - Tables go to `content/LibLouis/` in the package
 - `build/AccessMind.SharpLouis.targets` copies files to consumer's output directory
 - Targets are included in both `build/` and `buildTransitive/` for transitive dependency support
+
+### Build Configuration (CI-scoped)
+Several build settings are deliberately **scoped to CI** via `Condition="'$(GITHUB_ACTIONS)' == 'true'"`,
+because CI (full git history, `github.com` remote) is the warning-clean source of truth while local
+developer builds stay lenient. Do **not** remove this scoping to make local builds behave like CI.
+- `TreatWarningsAsErrors` — on only in CI, so environment-specific warnings don't hard-fail local builds.
+- `ContinuousIntegrationBuild` — on only in CI (deterministic/normalized build paths).
+- **Symbols & SourceLink** — the package ships `snupkg` symbols (`IncludeSymbols` +
+  `SymbolPackageFormat`) with `Microsoft.SourceLink.GitHub` so consumers can step into library source
+  from GitHub. `EnableSourceLink` is turned **off** off CI: a developer's git remote may be an SSH host
+  alias (e.g. `github:`) that SourceLink's GitHub provider can't resolve, which otherwise emits a benign
+  "source control information is not available" warning. SourceLink only matters for the CI-published
+  package, so local builds skip it.
 
 ### Release Process
 Cutting a release is deliberate and human-gated: push a `v*` git tag (GitVersion resolves the

--- a/README.md
+++ b/README.md
@@ -108,11 +108,13 @@ var frenchLiteraryTables = new TableCollection()
     .FindLiterary();
 ```
 
+The filter methods are non-destructive — each returns a new collection and leaves the receiver unchanged — so a single populated collection can be reused for several independent queries (for example calling `ListLanguages()` on the full set and `FindLiterary()` on the same instance).
+
 It has the following methods:
 
 * `TableCollection PopulateFromJson()` — Parses the JSON file provided with the library and returns a table collection instance populated from this file.
-* `TableCollection FindByLanguage(string language)` — Filters the table collection and finds all the tables of a given language.
-* `TableCollection FindLiterary()` — Filters the collection and finds all the translation tables supporting literary Braille.
+* `TableCollection FindByLanguage(string language)` — Returns a new collection of the tables of a given language, leaving the receiver unchanged.
+* `TableCollection FindLiterary()` — Returns a new collection of the tables supporting literary Braille, leaving the receiver unchanged.
 * `TranslationTable? FindByFileName(string fileName)` — Accepts a file name and finds the corresponding translation table, or `null` if no table with that file name exists.
 * `Dictionary<string, string> ListLanguages()` — Searches all the tables and lists the languages supported by those tables. Returns a dictionary where the key of each element is a language code and the value is its full English name.
 

--- a/src/SharpLouis/SharpLouis.csproj
+++ b/src/SharpLouis/SharpLouis.csproj
@@ -13,8 +13,8 @@
         <Nullable>enable</Nullable>
         <RootNamespace>AccessMind.SharpLouis</RootNamespace>
         <!-- Hold the shipping library to the same bar as the tests: warnings are build errors.
-             Scoped to CI so a missing local git context (SourceLink's empty-source-link warning)
-             doesn't break ordinary developer builds; CI has full history and stays warning-clean. -->
+             Scoped to CI as the warning-clean source of truth (full history, github.com remote);
+             local builds may surface environment-specific warnings we don't want to hard-fail on. -->
         <TreatWarningsAsErrors Condition="'$(GITHUB_ACTIONS)' == 'true'">true</TreatWarningsAsErrors>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
@@ -30,6 +30,12 @@
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+        <!-- SourceLink resolves source-file URLs from the git remote. Off CI the remote may be an SSH
+             host alias (e.g. "github:") that SourceLink's GitHub provider doesn't recognize, so it can't
+             build the link and emits a benign "source control information is not available" warning.
+             SourceLink only matters for the published package (built in CI with a github.com remote and
+             full history), so turn it off off CI to keep developer builds warning-clean. -->
+        <EnableSourceLink Condition="'$(GITHUB_ACTIONS)' != 'true'">false</EnableSourceLink>
 
         <!-- Package metadata -->
         <Product>SharpLouis</Product>

--- a/src/SharpLouis/TableCollection.cs
+++ b/src/SharpLouis/TableCollection.cs
@@ -21,7 +21,10 @@ namespace AccessMind.SharpLouis;
 /// of LibLouis, which is itself a result of tables processing made by the LLJT console utility.
 ///
 /// The primary use is the fluent filtering API (<see cref="PopulateFromJson"/>,
-/// <see cref="FindByLanguage"/>, <see cref="FindLiterary"/>, …). It also implements the full mutable
+/// <see cref="FindByLanguage"/>, <see cref="FindLiterary"/>, …). The filter methods are
+/// <b>non-destructive</b>: each returns a new collection and leaves the receiver unchanged, so a single
+/// populated collection can be reused for several independent queries (for example
+/// <see cref="ListLanguages"/> after <see cref="FindLiterary"/>). It also implements the full mutable
 /// <see cref="ICollection{T}"/> contract (<see cref="Add"/>, <see cref="Remove"/>, <see cref="Clear"/>,
 /// enumeration), so a collection can be populated by hand as well as from JSON.
 /// </summary>
@@ -29,6 +32,12 @@ namespace AccessMind.SharpLouis;
 public sealed class TableCollection: ICollection<TranslationTable> {
     private static readonly string TablesJson = Path.Combine(AppContext.BaseDirectory, "LibLouis", "tables.json");
     private List<TranslationTable> tables = [];
+
+    /// <summary>Creates an empty collection, ready to <see cref="PopulateFromJson"/> or be populated by hand.</summary>
+    public TableCollection() { }
+
+    /// <summary>Wraps an already-filtered list; used by the non-destructive filter methods.</summary>
+    private TableCollection(List<TranslationTable> tables) => this.tables = tables;
 
     public int Count => tables.Count;
 
@@ -41,15 +50,14 @@ public sealed class TableCollection: ICollection<TranslationTable> {
         return this;
     }
 
-    public TableCollection FindByLanguage(string language) {
-        this.tables = this.tables.FindAll(t => t.Language == language).ToList();
-        return this;
-    }
+    /// <summary>Returns a new collection of the tables for <paramref name="language"/>; the receiver is
+    /// left unchanged.</summary>
+    public TableCollection FindByLanguage(string language) =>
+        new(this.tables.FindAll(t => t.Language == language));
 
-    public TableCollection FindLiterary() {
-        this.tables = this.tables.FindAll(t => t.IsLiteraryBraille());
-        return this;
-    }
+    /// <summary>Returns a new collection of the literary-braille tables; the receiver is left unchanged.</summary>
+    public TableCollection FindLiterary() =>
+        new(this.tables.FindAll(t => t.IsLiteraryBraille()));
 
     public TranslationTable? FindByFileName(string fileName) {
         // List<T>.Find on a record struct returns default (all-null fields) on a miss, which is

--- a/tests/SharpLouis.Tests/TableCollectionTests.cs
+++ b/tests/SharpLouis.Tests/TableCollectionTests.cs
@@ -55,6 +55,34 @@ public class TableCollectionTests {
     }
 
     [Fact]
+    public void Filters_AreNonDestructive_LeaveSourceUnchanged() {
+        var all = Populated();
+        var total = all.Count;
+
+        var literary = all.FindLiterary();
+
+        literary.Count.Should().BeLessThan(total, "filtering should narrow the result");
+        all.Count.Should().Be(total, "the source collection must not be mutated by a filter");
+    }
+
+    [Fact]
+    public void Populated_CanBeReusedForIndependentQueries() {
+        // Regression: FindLiterary used to mutate in place, so a later ListLanguages saw only the
+        // literary subset and dropped languages whose only tables are non-literary.
+        var collection = Populated();
+
+        var literaryCount = collection.FindLiterary().Count;
+        var germanCount = collection.FindByLanguage("de").Count;
+        var languages = collection.ListLanguages();
+
+        literaryCount.Should().BeGreaterThan(0);
+        germanCount.Should().BeGreaterThan(0);
+        // ListLanguages ran on the full set, unaffected by the two filters above.
+        languages.Count.Should().BeGreaterThan(germanCount);
+        languages.Should().ContainKey("en");
+    }
+
+    [Fact]
     public void ListLanguages_MapsKnownCodesToEnglishNames() {
         var languages = Populated().ListLanguages();
         languages.Should().ContainKey("en");


### PR DESCRIPTION
## Summary

`TableCollection.FindByLanguage` / `FindLiterary` mutated the collection in place and returned `this`, contradicting the documented fluent interface. Reusing a populated instance for a second query gave wrong results — e.g. `ListLanguages()` after `FindLiterary()` listed only the languages that have a literary table, silently dropping the rest. Both filters now return a **new** collection and leave the receiver unchanged.

## Changes

- `TableCollection`: non-destructive `FindByLanguage`/`FindLiterary` via a private list-wrapping constructor; `PopulateFromJson()` stays a mutating loader.
- Tests: two regression tests (`Filters_AreNonDestructive_LeaveSourceUnchanged`, `Populated_CanBeReusedForIndependentQueries`) — the reuse cases the existing suite never exercised.
- Build: `EnableSourceLink` off CI, so local builds with a non-`github.com` remote alias no longer emit the benign "source control information is not available" warning.
- Docs: README (non-destructive contract), CHANGELOG (2.0.1), CLAUDE.md (filter contract + CI-scoped build settings).

All existing tests still pass (75/75), including `Filters_Chain_Fluently`, confirming compatibility with every documented usage.