### PR TITLE
Resolve names for ISO 639-2/3 codes ICU cannot name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed 🐛
+
+- `TableCollection.ListLanguages()` now returns real names for several ISO 639-2/3 codes that LibLouis
+  ships tables for but no .NET/ICU culture can name — `dra` (Dravidian), `hbo` (Classical Hebrew),
+  `mun` (Munda), `ovd` (Elfdalian), and `smi` (Sami). They previously surfaced as the bare code (for
+  example a language picker showing "ovd" instead of "Elfdalian").
+
 ## [2.0.1] — 2026-07-06
 
 ### Fixed 🐛

--- a/src/SharpLouis/TableCollection.cs
+++ b/src/SharpLouis/TableCollection.cs
@@ -84,12 +84,28 @@ public sealed class TableCollection: ICollection<TranslationTable> {
         return languages;
     }
 
+    // English names for ISO 639-2/3 codes that LibLouis ships tables for but no .NET/ICU culture can
+    // name (CultureInfo throws CultureNotFoundException). Without these, ListLanguages would surface the
+    // bare code (e.g. "ovd") to a UI. Keyed on the primary subtag, case-insensitively.
+    private static readonly Dictionary<string, string> KnownLanguageNames = new(StringComparer.OrdinalIgnoreCase) {
+        ["dra"] = "Dravidian",
+        ["hbo"] = "Classical Hebrew",
+        ["mun"] = "Munda",
+        ["ovd"] = "Elfdalian",
+        ["smi"] = "Sami",
+    };
+
     private static string GetEnglishName(string language) {
+        var primary = language.Split('-')[0];
+        if (KnownLanguageNames.TryGetValue(primary, out var known)) {
+            return known;
+        }
+
         try {
-            return new CultureInfo(language.Split('-')[0]).EnglishName;
+            return new CultureInfo(primary).EnglishName;
         } catch (CultureNotFoundException) {
-            // Some bundled tables use language codes that are not recognized .NET cultures
-            // (e.g. "awa", "bra", "cop"). Fall back to the raw code rather than throwing.
+            // A code no installed .NET/ICU culture recognizes and that isn't in KnownLanguageNames:
+            // fall back to the raw code rather than throwing.
             return language;
         }
     }

--- a/tests/SharpLouis.Tests/TableCollectionTests.cs
+++ b/tests/SharpLouis.Tests/TableCollectionTests.cs
@@ -106,6 +106,21 @@ public class TableCollectionTests {
     }
 
     [Fact]
+    public void ListLanguages_UsesCuratedName_ForCodesIcuCannotName() {
+        // ISO 639-2/3 codes LibLouis ships tables for but no .NET culture can name; ListLanguages must
+        // surface a real name rather than the bare code.
+        var collection = new TableCollection {
+            new TranslationTable("ovd.utb", "Elfdalian 6-dot braille", "ovd", "literary", "no", "both", 6),
+            new TranslationTable("smi.utb", "Sami 6-dot braille", "smi", "literary", "no", "both", 6),
+            new TranslationTable("hbo.utb", "Classical Hebrew braille", "hbo", "literary", "no", "both", 6),
+        };
+        var languages = collection.ListLanguages();
+        languages["ovd"].Should().Be("Elfdalian");
+        languages["smi"].Should().Be("Sami");
+        languages["hbo"].Should().Be("Classical Hebrew");
+    }
+
+    [Fact]
     public void ListLanguages_HasNoEmptyValues() {
         Populated().ListLanguages().Values.Should().OnlyContain(name => !string.IsNullOrEmpty(name));
     }


### PR DESCRIPTION
## Summary

`TableCollection.ListLanguages()` returned the bare code (e.g. `ovd`, `smi`) for a handful of ISO 639-2/3 codes that LibLouis ships tables for but no .NET/ICU culture can name, so a consumer's language picker showed codes instead of names.

`GetEnglishName` now consults a small curated map before the `CultureInfo` lookup:

| code | name |
|---|---|
| `dra` | Dravidian |
| `hbo` | Classical Hebrew |
| `mun` | Munda |
| `ovd` | Elfdalian |
| `smi` | Sami |

Anything not in the map still resolves via ICU, and a truly unknown code still falls back to the raw code (unchanged).

## Tests

Adds `ListLanguages_UsesCuratedName_ForCodesIcuCannotName`. Full suite: **76/76 pass**.